### PR TITLE
feat: make travis ci generate documents automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,14 @@ node_js:
 script:
   - sh ./bin/tslint.sh
 
+after_success:
+  - npm run typedoc
+
+deploy:
+  - provider: pages
+    skip_cleanup: true
+    local_dir: docs/
+    github_token: $GITHUB_PAGE_TOKEN
+
 notifications:
   slack: gagobigdata:674GLiXxbWRk8BXDTMQ076Ud

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "supertest": "^2.0.0",
     "tslint": "^4.3.1",
     "tslint-sakura-contrib": "^1.0.6",
+    "typedoc": "^0.10.0",
     "typescript": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "postpublish": "rm -rf ./lib; gulp ts; node ./lib/js/src/tools/sendchangelog.js; rm -rf ./lib;",
     "lint": "sh bin/tslint.sh",
     "test-mysql": "sh bin/test-mysql.sh",
-    "sample-mysql": "rm -rf ./lib; gulp ts; node ./lib/js/src/example/mysql/dbclient.js;"
+    "sample-mysql": "rm -rf ./lib; gulp ts; node ./lib/js/src/example/mysql/dbclient.js;",
+    "pretypedoc": "mkdir docs",
+    "typedoc": "./node_modules/typedoc/bin/typedoc --ignoreCompilerErrors --out ./docs --exclude test --excludePrivate --hideGenerator  --mode modules --tsconfig ./tsconfig.json ./src/",
+    "posttypedoc": "touch docs/.nojekyll"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To make travis ci generate documents automatically, you should do some additional configurations.

- github token: to get your $GITHUB_TOKEN you will need to go to https://github.com/settings/tokens and enable repo access.
![image](https://user-images.githubusercontent.com/34019224/36070307-cb2e1d86-0f32-11e8-9f9a-ce9f0081276a.png)

- travis env: add environment variables, "GITHUB_PAGE_TOKEN".
![image](https://user-images.githubusercontent.com/34019224/36070330-22b65136-0f33-11e8-9bc4-0cf2dc9b0381.png)

Finally, it will generate a branch, called gh-page, and you can get your document from your github page.
